### PR TITLE
APIキー入力欄とテキストエリアの表示改善

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,7 @@ function App() {
   }, []);
 
   useEffect(() => {
-    window.ipcRenderer.on('focus', (event, message) => {
+    window.ipcRenderer?.on('focus', (event, message) => {
       textareaRef.current?.focus();
 
       const clipboardText = window.clipboard.readText();
@@ -130,29 +130,33 @@ function App() {
     <div className="App">
       <h1>ChatGPT Electron App</h1>
       <p>Ctrl + Spaceでウィンドウ呼び出し</p>
-      {/* <label htmlFor="api-key">API Key:</label>
+      <label htmlFor="api-key">API Key:</label>
       <input
         id="api-key"
         type="text"
         value={apiKey}
         onChange={handleApiKeyChange}
         placeholder="Enter your OpenAI API key"
-      /> */}
-      <br/>
-      <textarea
-        ref={textareaRef}
-        value={userInput}
-        onChange={(e) => setUserInput(e.target.value)}
-        placeholder="Type your message here..."
-        onKeyUp={handleKeyPress}
-        rows={5}
       />
-      <br/>
-      Ctrl + Enterで送信
-      <hr/>
-      <h2>回答</h2>
-      {/* <button onClick={handleSend}>Send</button> */}
-      <div dangerouslySetInnerHTML={{__html: response}}></div>
+      { apiKey && (
+        <>
+          <hr/>
+          <h2>回答</h2>
+          {/* <button onClick={handleSend}>Send</button> */}
+          <div dangerouslySetInnerHTML={{__html: response}}></div>
+          <br/>
+          <textarea
+            ref={textareaRef}
+            value={userInput}
+            onChange={(e) => setUserInput(e.target.value)}
+            placeholder="Type your message here..."
+            onKeyUp={handleKeyPress}
+            rows={5}
+          />
+          <br/>
+          Ctrl + Enterで送信
+        </>
+      )}
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,11 @@ function App() {
   const [apiKey, setApiKey] = useState('');
   const [userInput, setUserInput] = useState('');
   const [response, setResponse] = useState('');
+  const [showApiKeyInput, setShowApiKeyInput] = useState(true);
+
+  const handleToggleApiKeyInput = () => {
+    setShowApiKeyInput(!showApiKeyInput);
+  };
 
   useEffect(() => {
     const storedApiKey = localStorage.getItem('apiKey');
@@ -130,14 +135,21 @@ function App() {
     <div className="App">
       <h1>ChatGPT Electron App</h1>
       <p>Ctrl + Spaceでウィンドウ呼び出し</p>
-      <label htmlFor="api-key">API Key:</label>
-      <input
-        id="api-key"
-        type="text"
-        value={apiKey}
-        onChange={handleApiKeyChange}
-        placeholder="Enter your OpenAI API key"
-      />
+      {showApiKeyInput ? (
+        <>
+          <label htmlFor="api-key">API Key:</label>
+          <input
+            id="api-key"
+            type="text"
+            value={apiKey}
+            onChange={handleApiKeyChange}
+            placeholder="Enter your OpenAI API key"
+          />
+          <button onClick={handleToggleApiKeyInput}>Hide API Key Input</button>
+        </>
+      ) : (
+        <button onClick={handleToggleApiKeyInput}>Show API Key Input</button>
+      )}
       { apiKey && (
         <>
           <hr/>


### PR DESCRIPTION
fix #1 

このプルリクエストでは、ユーザーエクスペリエンスを向上させるために、以下の2つの機能追加を行いました。

1. APIキーが入力されるまで、テキストエリアを非表示にする
   - ユーザーが入力するためのテキストエリアは、有効なAPIキーが入力されるまで非表示になります。これにより、ユーザーがチャット機能を使用する前にAPIキーを入力することを確認できます。

2. APIキー入力欄を隠すためのアコーディオンのような切り替え機能を追加
   - APIキーが確定された後、ユーザーはアコーディオンのような切り替え機能を使って入力欄を隠すことができるようになります。これにより、よりクリーンなユーザーインターフェースが提供され、視覚的な混雑が軽減されます。

これらの機能追加により、より使いやすく洗練されたアプリケーションが実現されることを目指しています。

変更点を確認していただき、ご意見や懸念事項があればお知らせください。よろしくお願いいたします！

## スクショ

<img width="912" alt="スクリーンショット 2023-04-01 8 55 25" src="https://user-images.githubusercontent.com/2221199/229251979-c04b0815-3395-4f80-8107-19cf68bcf416.png">
