### PR TITLE
メッセージ履歴の永続化機能の追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -41,3 +41,13 @@ textarea {
   width: 100%;
   font-size: 16px;
 }
+
+.user-message {
+  margin: 10px 0;
+  color: #0066cc;
+}
+
+.assistant-message {
+  margin: 10px 0;
+  color: #ff6600;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,12 @@ type Message = {
   content: string;
 };
 
+// メッセージ履歴を取得する関数
+const getMessageHistoryFromLocalStorage = (): Message[] => {
+  const storedHistory = localStorage.getItem('messageHistory');
+  return storedHistory ? JSON.parse(storedHistory) : [];
+};
+
 const utf8Decoder = new TextDecoder('utf-8')
 
 const decodeResponse = (response?: Uint8Array) => {
@@ -50,6 +56,11 @@ function App() {
     if (storedApiKey) {
       setApiKey(storedApiKey);
     }
+  }, []);
+
+  // アプリケーションがマウントされたときにメッセージ履歴をローカルストレージから取得
+  useEffect(() => {
+    setMessages(getMessageHistoryFromLocalStorage());
   }, []);
 
   useEffect(() => {
@@ -123,8 +134,13 @@ function App() {
       }
 
       setResponse('');
-      setMessages((prevMessages) => [...prevMessages, { role: 'assistant', content: markdownit().render(fullText) }]);
-
+      setMessages((prevMessages) => {
+        // メッセージ履歴を更新
+        const updatedMessages = [...prevMessages, { role: 'assistant', content: markdownit().render(fullText) } as Message];
+        // メッセージ履歴をローカルストレージに保存
+        localStorage.setItem('messageHistory', JSON.stringify(updatedMessages));
+        return updatedMessages;
+      });
     } catch (error) {
       console.error(error);
       setResponse('Error: Failed to get a response from ChatGPT.');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,11 @@ declare global {
   }
 }
 
+type Message = {
+  role: 'user' | 'assistant';
+  content: string;
+};
+
 const utf8Decoder = new TextDecoder('utf-8')
 
 const decodeResponse = (response?: Uint8Array) => {
@@ -34,6 +39,7 @@ function App() {
   const [userInput, setUserInput] = useState('');
   const [response, setResponse] = useState('');
   const [showApiKeyInput, setShowApiKeyInput] = useState(true);
+  const [messages, setMessages] = useState<Message[]>([]);
 
   const handleToggleApiKeyInput = () => {
     setShowApiKeyInput(!showApiKeyInput);
@@ -66,6 +72,8 @@ function App() {
 
   const handleSend = async () => {
     if (!userInput || !apiKey) return;
+
+    setMessages((prevMessages) => [...prevMessages, { role: 'user', content: userInput }]);
 
     const configuration = new Configuration({
       apiKey
@@ -114,9 +122,9 @@ function App() {
         setResponse(markdownit().render(fullText));
       }
 
-      // for await (const message of streamCompletion(result))
-      // const generatedResponse = result?.data.choices[0].message?.content;
-      // setResponse(`${generatedResponse && markdownit().render(generatedResponse)}`);
+      setResponse('');
+      setMessages((prevMessages) => [...prevMessages, { role: 'assistant', content: markdownit().render(fullText) }]);
+
     } catch (error) {
       console.error(error);
       setResponse('Error: Failed to get a response from ChatGPT.');
@@ -153,8 +161,19 @@ function App() {
       { apiKey && (
         <>
           <hr/>
-          <h2>回答</h2>
           {/* <button onClick={handleSend}>Send</button> */}
+
+          {/* messagesステートを繰り返し処理して、メッセージを表示 */}
+          <div className="messages">
+            {messages.map((message, index) => (
+              <div
+                key={index}
+                className={message.role === 'user' ? 'user-message' : 'assistant-message'}
+                dangerouslySetInnerHTML={{ __html: message.content }}
+              ></div>
+            ))}
+          </div>
+          {/* リアルタイムのメッセージを表示 */}
           <div dangerouslySetInnerHTML={{__html: response}}></div>
           <br/>
           <textarea


### PR DESCRIPTION
fix #4 

このプルリクエストでは、ChatGPT Electronアプリケーションで前回の質問と回答を表示する機能を追加します。

主な変更点:

1. ユーザーとChatGPTのメッセージ履歴をローカルストレージに保存
2. アプリ起動時にローカルストレージからメッセージ履歴を取得し、表示するように変更

これにより、ユーザーがアプリケーションを再起動しても前回の質問と回答を確認できるようになります。レビューとフィードバックをお願いいたします。

<img width="912" alt="スクリーンショット 2023-04-01 9 43 21" src="https://user-images.githubusercontent.com/2221199/229257148-381f6adc-137d-46e1-9d22-1e90d5f8a105.png">
