### PR TITLE
チャット履歴を利用してGPT-3.5-turboモデルにリクエストを送信する機能を追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,12 +93,10 @@ function App() {
 
     const requestOptions: CreateChatCompletionRequest = {
       model: 'gpt-3.5-turbo',
-      messages: [
-        {
+      messages: messages.concat({
           role: ChatCompletionRequestMessageRoleEnum.User,
           content: `User: ${userInput}\nAssistant:`,
-        }
-      ],
+      }),
       max_tokens: 1500,
       n: 1,
       temperature: 0.8,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -157,6 +157,12 @@ function App() {
     }
   };
 
+  // 履歴を削除する
+  const handleClearHistory = () => {
+    localStorage.removeItem('messageHistory');
+    setMessages([]);
+  };
+
   return (
     <div className="App">
       <h1>ChatGPT Electron App</h1>
@@ -176,6 +182,7 @@ function App() {
       ) : (
         <button onClick={handleToggleApiKeyInput}>Show API Key Input</button>
       )}
+      <button onClick={handleClearHistory}>Clear History</button>
       { apiKey && (
         <>
           <hr/>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ declare global {
 type Message = {
   role: 'user' | 'assistant';
   content: string;
+  html: string;
 };
 
 // メッセージ履歴を取得する関数
@@ -84,7 +85,7 @@ function App() {
   const handleSend = async () => {
     if (!userInput || !apiKey) return;
 
-    setMessages((prevMessages) => [...prevMessages, { role: 'user', content: userInput }]);
+    setMessages((prevMessages) => [...prevMessages, { role: 'user', content: userInput, html: markdownit().render(userInput) }]);
 
     const configuration = new Configuration({
       apiKey
@@ -95,7 +96,10 @@ function App() {
       model: 'gpt-3.5-turbo',
       messages: messages.concat({
           role: ChatCompletionRequestMessageRoleEnum.User,
-          content: `User: ${userInput}\nAssistant:`,
+          content: `${userInput}`,
+          html: markdownit().render(userInput),
+      }).map((message) => {
+        return {...message, html: undefined};
       }),
       max_tokens: 1500,
       n: 1,
@@ -134,7 +138,7 @@ function App() {
       setResponse('');
       setMessages((prevMessages) => {
         // メッセージ履歴を更新
-        const updatedMessages = [...prevMessages, { role: 'assistant', content: markdownit().render(fullText) } as Message];
+        const updatedMessages = [...prevMessages, { role: 'assistant', content: fullText, html: markdownit().render(fullText) } as Message];
         // メッセージ履歴をローカルストレージに保存
         localStorage.setItem('messageHistory', JSON.stringify(updatedMessages));
         return updatedMessages;
@@ -183,7 +187,7 @@ function App() {
               <div
                 key={index}
                 className={message.role === 'user' ? 'user-message' : 'assistant-message'}
-                dangerouslySetInnerHTML={{ __html: message.content }}
+                dangerouslySetInnerHTML={{ __html: message.html }}
               ></div>
             ))}
           </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,6 @@ declare global {
 type Message = {
   role: 'user' | 'assistant';
   content: string;
-  html: string;
 };
 
 // メッセージ履歴を取得する関数
@@ -85,7 +84,7 @@ function App() {
   const handleSend = async () => {
     if (!userInput || !apiKey) return;
 
-    setMessages((prevMessages) => [...prevMessages, { role: 'user', content: userInput, html: markdownit().render(userInput) }]);
+    setMessages((prevMessages) => [...prevMessages, { role: 'user', content: userInput }]);
 
     const configuration = new Configuration({
       apiKey
@@ -97,9 +96,6 @@ function App() {
       messages: messages.concat({
           role: ChatCompletionRequestMessageRoleEnum.User,
           content: `${userInput}`,
-          html: markdownit().render(userInput),
-      }).map((message) => {
-        return {...message, html: undefined};
       }),
       max_tokens: 1500,
       n: 1,
@@ -138,7 +134,7 @@ function App() {
       setResponse('');
       setMessages((prevMessages) => {
         // メッセージ履歴を更新
-        const updatedMessages = [...prevMessages, { role: 'assistant', content: fullText, html: markdownit().render(fullText) } as Message];
+        const updatedMessages = [...prevMessages, { role: 'assistant', content: fullText } as Message];
         // メッセージ履歴をローカルストレージに保存
         localStorage.setItem('messageHistory', JSON.stringify(updatedMessages));
         return updatedMessages;
@@ -194,7 +190,7 @@ function App() {
               <div
                 key={index}
                 className={message.role === 'user' ? 'user-message' : 'assistant-message'}
-                dangerouslySetInnerHTML={{ __html: message.html }}
+                dangerouslySetInnerHTML={{ __html: markdownit().render(message.content) }}
               ></div>
             ))}
           </div>


### PR DESCRIPTION
fix #6 

## 概要
このプルリクエストでは、ChatGPT Electronアプリで過去のチャット履歴を利用してGPT-3.5-turboモデルにリクエストを送信する機能を追加しました。

## 主な変更点
- メッセージの状態を追加し、メッセージ履歴を管理
- メッセージ履歴をローカルストレージから取得し、状態に設定
- メッセージ履歴をローカルストレージに保存する処理を追加
- GPT-3.5-turboモデルにリクエストを送信する際、メッセージ履歴を含めるように変更
- メッセージ履歴を表示するコンポーネントを追加

## テスト手順
1. アプリを起動し、APIキーを入力
2. ユーザーとアシスタントのメッセージを交換して、チャット履歴が正しく表示されることを確認
3. アプリを再起動し、以前のチャット履歴が正しく表示されることを確認
4. 新しいメッセージを送信し、アシスタントの回答が以前のチャット履歴を考慮していることを確認

## 影響範囲
この変更により、ユーザーが過去のチャット履歴を維持し、それを活用してGPT-3.5-turboモデルにリクエストを送信できるようになります。これにより、アシスタントの回答がよりコンテキストに応じたものになります。

## 補足情報
なし

## スクリーンショット

<img width="1371" alt="image" src="https://user-images.githubusercontent.com/2221199/229258534-9419d64d-2170-4f37-b8f0-c5b2fc8cbfa8.png">
