### PR TITLE
Markdown形式のテキストをクリップボードにコピーする機能を追加

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,6 +159,11 @@ function App() {
     setMessages([]);
   };
 
+  // メッセージをクリップボードにコピーする
+  const handleCopyToClipboard = (message: Message) => {
+    window.clipboard.writeText(message.content);
+  };
+
   return (
     <div className="App">
       <h1>ChatGPT Electron App</h1>
@@ -187,11 +192,15 @@ function App() {
           {/* messagesステートを繰り返し処理して、メッセージを表示 */}
           <div className="messages">
             {messages.map((message, index) => (
-              <div
-                key={index}
-                className={message.role === 'user' ? 'user-message' : 'assistant-message'}
-                dangerouslySetInnerHTML={{ __html: markdownit().render(message.content) }}
-              ></div>
+              <>
+                <div
+                  key={index}
+                  className={message.role === 'user' ? 'user-message' : 'assistant-message'}
+                  dangerouslySetInnerHTML={{ __html: markdownit().render(message.content) }}
+                ></div>
+                {/* コピー用ボタンを追加 */}
+                <button onClick={() => handleCopyToClipboard(message)}>Copy to Clipboard</button>
+              </>
             ))}
           </div>
           {/* リアルタイムのメッセージを表示 */}


### PR DESCRIPTION
fix #10

このPull Requestでは、Electronアプリでアシスタントの回答をMarkdown形式で表示し、クリップボードにコピーする機能を追加します。

主な変更点:
- ~~`markdown-it` と `clipboard` パッケージをインポート~~ すでにインポート済み
- `handleCopyToClipboard` 関数を追加
- 「Copy to Clipboard」ボタンを追加し、`onClick` イベントで `handleCopyToClipboard` 関数を呼び出すように設定

これにより、ユーザーは「Copy to Clipboard」ボタンをクリックすることで、アシスタントの回答をMarkdown形式でクリップボードにコピーできるようになります。

<img width="912" alt="image" src="https://user-images.githubusercontent.com/2221199/229259867-f1e5b6fa-7029-4108-b7d7-be0367ba1596.png">
