### PR TITLE
自動スクロール機能の追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -56,3 +56,7 @@ textarea {
   text-align: right;
   opacity: 0.35;
 }
+
+.messagesEnd {
+  height: 20px;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ function App() {
   const [response, setResponse] = useState('');
   const [showApiKeyInput, setShowApiKeyInput] = useState(true);
   const [messages, setMessages] = useState<Message[]>([]);
+  const messagesEndRef = React.useRef<HTMLDivElement>(null);
 
   const handleToggleApiKeyInput = () => {
     setShowApiKeyInput(!showApiKeyInput);
@@ -173,6 +174,16 @@ function App() {
     }
   };
 
+  // スクロールを一番下に移動する
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  // responseやmessagesが変更されたときにスクロール処理を実行
+  useEffect(() => {
+    scrollToBottom();
+  }, [response, messages]);
+
   return (
     <div className="App">
       <h1>ChatGPT Electron App</h1>
@@ -227,6 +238,7 @@ function App() {
           />
           <br/>
           Ctrl + Enterで送信
+          <div ref={messagesEndRef} />
         </>
       )}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -238,7 +238,7 @@ function App() {
           />
           <br/>
           Ctrl + Enterで送信
-          <div ref={messagesEndRef} />
+          <div className="messagesEnd" ref={messagesEndRef} />
         </>
       )}
     </div>


### PR DESCRIPTION
fix #12

このプルリクエストでは、ユーザーがメッセージを送信した際や、新しいリアルタイムのメッセージが表示された際に、自動的にウィンドウを一番下にスクロールする機能を追加しました。

主な変更点:
- `response` `messages` ステートが更新されたときにウィンドウを一番下にスクロールするように変更
- 新たに `messagesEndRef` という ref を作成し、メッセージの一番下に空の `div` を配置

これにより、ユーザーがメッセージを送信した際や、新しいリアルタイムのメッセージが表示された際に、ウィンドウが一番下にスクロールされるようになります。
