### PR TITLE
履歴をMarkdown形式でクリップボードにコピーする

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -184,6 +184,31 @@ function App() {
     scrollToBottom();
   }, [response, messages]);
 
+  // 履歴をMarkdown形式でクリップボードにコピーする
+  const handleExportHistory = async () => {
+    // メッセージ履歴をMarkdown形式のテキストに変換する
+    const markdownHistory = messages.map((message) => {
+      if (message.role === "user") {
+        return `\`\`\`\n${message.content}\n\`\`\`\n↓\n`;
+      } else {
+        return `${message.content}\n\n----\n`;
+      }
+    }).join("");
+
+    // クリップボードにコピーする
+    try {
+      if (window.clipboard?.writeText) {
+        window.clipboard.writeText(markdownHistory);
+      } else {
+        await navigator.clipboard.writeText(markdownHistory);
+      }
+      alert("Message history has been copied to the clipboard.");
+    } catch (err) {
+      console.error("Failed to copy message history to the clipboard: ", err);
+      alert("Failed to copy message history to the clipboard.");
+    }
+  };
+
   return (
     <div className="App">
       <h1>ChatGPT Electron App</h1>
@@ -204,6 +229,7 @@ function App() {
         <button onClick={handleToggleApiKeyInput}>Show API Key Input</button>
       )}
       <button onClick={handleClearHistory}>Clear History</button>
+      <button onClick={handleExportHistory}>Export History</button>
       { apiKey && (
         <>
           <hr/>


### PR DESCRIPTION
fix #14

このプルリクエストは、チャット履歴をクリップボードにエクスポートする機能を追加します。ユーザーは、Exportボタンをクリックすることで、チャット履歴のMarkdown形式をクリップボードにコピーできます。この機能は、ユーザーがチャット履歴を外部のアプリケーションに転送する場合や、後で参照するために保存する場合に役立ちます。

変更内容:

- `handleExportHistory`関数を追加し、チャット履歴をMarkdown形式でクリップボードにコピーする機能を実装しました。
- Exportボタンを追加し、ユーザーがクリックしてチャット履歴をクリップボードにエクスポートできるようにしました。

動作確認:

- アプリを起動し、チャット履歴をいくつか追加します。
- Exportボタンをクリックし、チャット履歴がクリップボードにコピーされることを確認します。

このプルリクエストをマージすることで、ユーザーがチャット履歴をクリップボードにエクスポートできるようになります。

<img width="483" alt="image" src="https://user-images.githubusercontent.com/2221199/229262420-3d14690c-e9a5-423e-8169-64a77c76359d.png">
